### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/pf1747/5e425b8b-fd70-4749-b9cd-1bab9e5ea957/a4371343-3fa5-4e2e-9442-833ba3ef2d4e/_apis/work/boardbadge/a83294cb-9db2-49a3-8720-663906dd5415)](https://dev.azure.com/pf1747/5e425b8b-fd70-4749-b9cd-1bab9e5ea957/_boards/board/t/a4371343-3fa5-4e2e-9442-833ba3ef2d4e/Microsoft.RequirementCategory)
 # hello-world


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/pf1747/5e425b8b-fd70-4749-b9cd-1bab9e5ea957/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.